### PR TITLE
Fix authentication to work with Authlib v1.3.1 and update to v1.3.1

### DIFF
--- a/haico/views.py
+++ b/haico/views.py
@@ -30,7 +30,7 @@ def login_view(request: HttpRequest) -> HttpResponse:
 
 def auth_view(request: HttpRequest) -> HttpResponse:
     token = oauth.org.authorize_access_token(request)
-    user = oauth.org.parse_id_token(request, token)
+    user = oauth.org.parse_id_token(token, token['userinfo']['nonce'])
     user = auth.update_user(user)
     login(request, user)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-crispy-forms==2.0
 crispy-bootstrap4==2022.1
 django-tables2==2.6.0
 Jinja2==3.1.2
-Authlib==1.2.1
+Authlib==1.3.1
 requests==2.31.0
 python-slugify[unidecode]==8.0.1
 tablib==3.5.0


### PR DESCRIPTION
Fix parse_id_token call in `haico/views.py` to work with Authlib v1.3.1 and update `requirements.txt` to Authlib v1.3.1