### PR TITLE
fix CSRF error

### DIFF
--- a/haico/settings.py
+++ b/haico/settings.py
@@ -38,6 +38,7 @@ DEBUG = True
 HOST_DOMAIN = '127.0.0.1'
 BASE_URL = f'http://{HOST_DOMAIN}:8000'
 ALLOWED_HOSTS = [HOST_DOMAIN]
+CSRF_TRUSTED_ORIGINS = [BASE_URL]
 
 # Application definition
 


### PR DESCRIPTION
add `CSRF_TRUSTED_ORIGINS` variable and link to `BASE_URL` in `haico/settings.py` to fix CSRF error when uploading new content